### PR TITLE
Add support for negative prompt weighting

### DIFF
--- a/scripts/openvino_accelerate.py
+++ b/scripts/openvino_accelerate.py
@@ -887,10 +887,12 @@ def process_images_openvino(p: StableDiffusionProcessing, model_config, sampler_
             #apply A1111 styled prompt weighting
             cond = prompt_parser.SdConditioning(p.prompts, width=p.width, height=p.height)
             prompt_embeds = p.sd_model.get_learned_conditioning(cond)
+            negative_cond = prompt_parser.SdConditioning(p.negative_prompts, width=p.width, height=p.height, is_negative_prompt=True)
+            negative_prompt_embeds = p.sd_model.get_learned_conditioning(negative_cond)
 
             output = shared.sd_diffusers_model(
                     prompt_embeds=prompt_embeds,
-                    negative_prompt=p.negative_prompts,
+                    negative_prompt_embeds=negative_prompt_embeds,
                     num_inference_steps=p.steps,
                     guidance_scale=p.cfg_scale,
                     generator=generator,


### PR DESCRIPTION
## Description

Thank you both so much for the very rapid response to issue https://github.com/openvinotoolkit/stable-diffusion-webui/issues/43 with pull request https://github.com/openvinotoolkit/stable-diffusion-webui/pull/46!

I think it would be good  to support prompt weights on the negative prompt as well. I believe this is supported when not using OpenVINO acceleration.

I think I have been able to implement this myself following the example of https://github.com/openvinotoolkit/stable-diffusion-webui/pull/46.

## Screenshots/videos:

I've experimented with prompt:
```
Evening street scene, New York, 1930
```
and negative prompt:
```
lamp, (people:1.5)
```
If I run this without OpenVINO acceleration, I get:
![00018-879204008-fixedprompt-cpu-2m50](https://github.com/openvinotoolkit/stable-diffusion-webui/assets/100809367/b97039b8-a85a-4fd7-bac1-77ad1372df5c)

If I run this with OpenVINO acceleration without this code change, I get:
![00020-879204008-fixedprompt-openvino-1m49](https://github.com/openvinotoolkit/stable-diffusion-webui/assets/100809367/5ff5c005-1b13-43d2-858a-6d9a92e0323a)
Note that the two are different.

With OpenVINO acceleration with this code change, I get:
![00019-879204008-fixedprompt-openvinopatched-1m18](https://github.com/openvinotoolkit/stable-diffusion-webui/assets/100809367/0290ff1f-45ed-42ba-acd1-49f547741fad)
This more-or-less matches the non-accelerated version, which suggests to me that the change is working correctly.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)

(I have tried to run the tests but they fail with an error "No module named 'gradio'". This happens with or without my code change.)