### PR TITLE
fix(script): fix the error when load the refiner model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ notification.mp3
 /node_modules
 /package-lock.json
 /.coverage*
+
+/cache

--- a/scripts/openvino_accelerate.py
+++ b/scripts/openvino_accelerate.py
@@ -675,7 +675,7 @@ def get_diffusers_sd_refiner_model(model_config, vae_ckpt, sampler_name, enable_
         if refiner_ckpt != "None":
             refiner_checkpoint_path= os.path.join(curr_dir_path, 'models', 'Stable-diffusion', refiner_ckpt)
             refiner_checkpoint_info = CheckpointInfo(refiner_checkpoint_path)
-            refiner_model = StableDiffusionXLImg2ImgPipeline.from_single_file(refiner_checkpoint_path, use_safetensors=True, torch_dtype=torch.float32)
+            refiner_model = StableDiffusionImg2ImgPipeline.from_single_file(refiner_checkpoint_path, use_safetensors=True, torch_dtype=torch.float32)
             refiner_model.watermark = NoWatermark()
             refiner_model.sd_checkpoint_info = refiner_checkpoint_info
             refiner_model.sd_model_hash = refiner_checkpoint_info.calculate_shorthash()


### PR DESCRIPTION
## Description

I found that when I select a refiner model in the options of the script, it caused a error.

```
Traceback (most recent call last):
  File "D:\stable-diffusion-webui\modules\call_queue.py", line 57, in f
    res = list(func(*args, **kwargs))
  File "D:\stable-diffusion-webui\modules\call_queue.py", line 36, in f
    res = func(*args, **kwargs)
  File "D:\stable-diffusion-webui\modules\txt2img.py", line 52, in txt2img
    processed = modules.scripts.scripts_txt2img.run(p, *args)
  File "D:\stable-diffusion-webui\modules\scripts.py", line 601, in run
    processed = script.run(p, *script_args)
  File "D:\stable-diffusion-webui\scripts\openvino_accelerate.py", line 1277, in run
    processed = process_images_openvino(p, model_config, vae_ckpt, p.sampler_name, enable_caching, override_hires, upscaler, hires_steps, d_strength, openvino_device, mode, is_xl_ckpt, refiner_ckpt, refiner_frac)
  File "D:\stable-diffusion-webui\scripts\openvino_accelerate.py", line 919, in process_images_openvino
    shared.sd_refiner_model = get_diffusers_sd_refiner_model(model_config, vae_ckpt, sampler_name, enable_caching, openvino_device, mode, is_xl_ckpt, refiner_ckpt, refiner_frac)
  File "D:\stable-diffusion-webui\scripts\openvino_accelerate.py", line 679, in get_diffusers_sd_refiner_model
    refiner_model = StableDiffusionXLImg2ImgPipeline.from_single_file(refiner_checkpoint_path, use_safetensors=True, torch_dtype=torch.float32)
  File "D:\stable-diffusion-webui\venv\lib\site-packages\diffusers\loaders.py", line 2822, in from_single_file
    pipe = download_from_original_stable_diffusion_ckpt(
  File "D:\stable-diffusion-webui\venv\lib\site-packages\diffusers\pipelines\stable_diffusion\convert_from_ckpt.py", line 1670, in download_from_original_stable_diffusion_ckpt
    pipe = pipeline_class(
TypeError: StableDiffusionXLImg2ImgPipeline.__init__() got an unexpected keyword argument 'safety_checker'
```

It is because that the script use `StableDiffusionXLImg2ImgPipeline.from_single_file` to load the refiner model, but the constructor of `StableDiffusionXLImg2ImgPipeline` require different parameters.

I don't understand why this is the case, but when I replace the `StableDiffusionXLImg2ImgPipeline` with `StableDiffusionImg2ImgPipeline`, it works.

I also modify the .gitignore to ignore the cache

## Screenshots/videos:


## Checklist:

- [*] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [*] I have performed a self-review of my own code
- [*] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [*] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
